### PR TITLE
change PySide to PyQt5

### DIFF
--- a/ArchitectureDialog.py
+++ b/ArchitectureDialog.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 
 
 class ArchitectureDialog(QDialog):

--- a/AssembleDialog.py
+++ b/AssembleDialog.py
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 from Fonts import *
 from TextEditor import *
 import nasm

--- a/DisassemblerView.py
+++ b/DisassemblerView.py
@@ -49,7 +49,7 @@ class DisassemblerHistoryEntry:
 		self.highlight_token = view.highlight_token
 
 class DisassemblerView(QAbstractScrollArea):
-	statusUpdated = Signal(QWidget, name="statusUpdated")
+	statusUpdated = pyqtSignal(QWidget, name="statusUpdated")
 
 	def __init__(self, data, filename, view, parent):
 		super(DisassemblerView, self).__init__(parent)
@@ -288,8 +288,8 @@ class DisassemblerView(QAbstractScrollArea):
 			for edge in block.edges:
 				p.setPen(edge.color)
 				p.setBrush(edge.color)
-				p.drawPolyline(edge.polyline)
-				p.drawConvexPolygon(edge.arrow)
+				p.drawPolyline(QPolygon(edge.polyline))
+				p.drawConvexPolygon(QPolygon(edge.arrow))
 
 	def isMouseEventInBlock(self, event):
 		# Convert coordinates to system used in blocks

--- a/FindDialog.py
+++ b/FindDialog.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 import re
 import sys
 

--- a/Fonts.py
+++ b/Fonts.py
@@ -14,8 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 
 monospaceFont = None
 lineSpacing = None

--- a/HelpView.py
+++ b/HelpView.py
@@ -15,10 +15,12 @@
 
 import sys
 import os
-from PySide.QtCore import *
-from PySide.QtGui import *
-from PySide.QtWebKit import *
-from PySide.QtNetwork import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWebKit import *
+from PyQt5.QtNetwork import *
+from PyQt5.QtWidgets import *
+from PyQt5.QtWebKitWidgets import QWebView
 from View import *
 
 

--- a/HexEditor.py
+++ b/HexEditor.py
@@ -14,8 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 from Fonts import *
 from View import *
 from BinaryData import *
@@ -31,7 +31,7 @@ class HexEditorHistoryEntry:
 		self.ascii = view.cursorAscii
 
 class HexEditor(QAbstractScrollArea):
-	statusUpdated = Signal(QWidget, name="statusUpdated")
+	statusUpdated = pyqtSignal(QWidget, name="statusUpdated")
 
 	def __init__(self, data, filename, view, parent):
 		super(HexEditor, self).__init__(parent)

--- a/Preferences.py
+++ b/Preferences.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 from Fonts import *
 
 

--- a/PythonConsole.py
+++ b/PythonConsole.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 from Fonts import *
 import code
 import sys
@@ -163,8 +164,8 @@ class PythonConsoleThread(threading.Thread):
 				self.done.set()
 
 class PythonConsoleLineEdit(QLineEdit):
-	prevHistory = Signal(())
-	nextHistory = Signal(())
+	prevHistory = pyqtSignal(())
+	nextHistory = pyqtSignal(())
 
 	def __init__(self, *args):
 		super(PythonConsoleLineEdit, self).__init__(*args)

--- a/RunWindow.py
+++ b/RunWindow.py
@@ -14,8 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import shlex
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 from TerminalView import *
 
 

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -14,8 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 from TerminalProcess import *
 from Fonts import *
 

--- a/TextEditor.py
+++ b/TextEditor.py
@@ -15,8 +15,8 @@
 
 import sys
 import os
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 from Fonts import *
 from View import *
 from BinaryData import *
@@ -41,7 +41,7 @@ class TextEditorHistoryEntry:
 
 
 class TextEditor(QAbstractScrollArea):
-	statusUpdated = Signal(QWidget, name="statusUpdated")
+	statusUpdated = pyqtSignal(QWidget, name="statusUpdated")
 
 	def __init__(self, data, filename, view, parent):
 		super(TextEditor, self).__init__(parent)

--- a/Threads.py
+++ b/Threads.py
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 import thread
 import threading
 

--- a/Transform.py
+++ b/Transform.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 from Crypto.Cipher import AES
 from Crypto.Cipher import Blowfish
 from Crypto.Cipher import CAST

--- a/Util.py
+++ b/Util.py
@@ -14,8 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import struct
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 from Crypto.Hash import MD2
 from Crypto.Hash import MD4
 from Crypto.Hash import MD5

--- a/View.py
+++ b/View.py
@@ -14,8 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 from PythonConsole import *
 
 ViewTypes = []
@@ -29,9 +29,9 @@ class HistoryEntry:
 		self.data = data
 
 class ViewFrame(QWidget):
-	statusUpdated = Signal(QWidget)
-	viewChanged = Signal(QWidget)
-	closeRequest = Signal(QWidget)
+	statusUpdated = pyqtSignal(QWidget)
+	viewChanged = pyqtSignal(QWidget)
+	closeRequest = pyqtSignal(QWidget)
 
 	def __init__(self, type, data, filename, viewList):
 		super(ViewFrame, self).__init__(None)

--- a/binja.py
+++ b/binja.py
@@ -23,8 +23,8 @@ import zlib
 import stat
 import thread
 import Threads
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 from View import *
 from BinaryData import *
 from HexEditor import *

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Binary Ninja and the Binary Ninja logo are trademarks of Vector 35 LLC.
 Binary Ninja is cross-platform and can run on Linux, Mac OS X, Windows, and FreeBSD. In order to run Binary Ninja, you will need to install a few prerequisites:
 
 * [Python 2.7](https://www.python.org/downloads/)
-* [PySide](https://pypi.python.org/pypi/PySide#installing-prerequisites) for Qt Python bindings
+* [PyQt5](http://www.riverbankcomputing.com/software/pyqt/download5) for Qt Python bindings
 * The [pycrypto](https://www.dlitz.net/software/pycrypto/) library
 
 You can start Binary Ninja by running `binja.py` in the Python interpreter.


### PR DESCRIPTION
Here is a PR for using PyQt5 instead of PySide.

But I found that It maybe somewhat difficult for building PyQt5 under Python2 but not Python3.
for example,
- the website of [PyQt5](http://www.riverbankcomputing.com/software/pyqt/download5) don't provide Binary Packages of windows for Python2, you need to build it from source by hand.
- when I build PyQt-5.3.2  for Python2 under Mac OSX, I happended to this compile problem: [Issues building PyQt5 for Python3.4 in Ubuntu 14.04 caused by qprinter.h not found then pyuic5 error](http://stackoverflow.com/questions/26560673/issues-building-pyqt5-for-python3-4-in-ubuntu-14-04-caused-by-qprinter-h-not-fou).(notice that it is not the newest version, for I had the not-so-new version of Qt5 compiled in my machine and I don't want to rebuild that. This problem seem fixed in the newest version of PyQt5)

Take care of this before accepting this PR ;)
